### PR TITLE
Fix diagnosis delete action

### DIFF
--- a/HMSproject/Controllers/SearchController.cs
+++ b/HMSproject/Controllers/SearchController.cs
@@ -187,15 +187,21 @@ namespace HMSproject.Controllers
         //Post
         [HttpPost]
 
-        public IActionResult Delete(Diagnose k,string? Id)
+        [ValidateAntiForgeryToken]
+        public IActionResult Delete(int id)
         {
+            var diagnosis = _db.Diagnose.Find(id);
+            if (diagnosis == null)
+            {
+                return NotFound();
+            }
 
-            _db.Diagnose.Remove(k);
+            _db.Diagnose.Remove(diagnosis);
             _db.SaveChanges();
             TempData["sure"] = "The Data has been delete successfully";
             return RedirectToAction("Spatient");
-            
-          
+
+
         }
 
 

--- a/HMSproject/Views/Search/delete.cshtml
+++ b/HMSproject/Views/Search/delete.cshtml
@@ -107,6 +107,7 @@
             </div>
 
             <form method="post" asp-action="Delete" asp-controller="Search">
+                <input type="hidden" asp-for="Id" />
                 <!-- Textarea 2 rows height -->
                 <div class="form-outline">
                     <label asp-for="Description" style="color: black;" class="form-label" for="textAreaExample3">Description </label>


### PR DESCRIPTION
## Summary
- fix deletion logic in SearchController so the correct diagnosis record is removed
- send diagnosis id from the delete page to the controller

## Testing
- `dotnet build HMSproject/HMSproject.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe38e4a4c8327871e1a754b4955e7